### PR TITLE
Dependency to ros2_livox_simulation package added

### DIFF
--- a/hunter_pltf_bringup/package.xml
+++ b/hunter_pltf_bringup/package.xml
@@ -3,9 +3,10 @@
 <package format="3">
   <name>hunter_pltf_bringup</name>
   <version>0.0.0</version>
-  <description>TODO: Package description</description>
-  <maintainer email="hariharan@todo.todo">hariharan</maintainer>
-  <license>TODO: License declaration</license>
+  <description>Bring up package for Hunter platform, part of the Agri-OpenCore (AOC) project</description>
+  <maintainer email="ihroob@lincoln.ac.uk">ihroob</maintainer>
+  <author email="ihroob@lincoln.ac.uk">ihroob</author>
+  <license>Apache-2.0</license>
 
   <buildtool_depend>ament_cmake</buildtool_depend>
 
@@ -14,6 +15,7 @@
   <exec_depend>robot_state_publisher</exec_depend>
   <exec_depend>hunter_base</exec_depend>
   <exec_depend>hunter_pltf_description</exec_depend>
+  <exec_depend>ros2_livox_simulation</exec_depend>
   
   <export>
     <build_type>ament_cmake</build_type>


### PR DESCRIPTION
<!--
     For Work In Progress Pull Requests, please use the Draft PR feature,
     see https://github.blog/2019-02-14-introducing-draft-pull-requests/ for further details.

-->

## What type of PR is this? (check all applicable)

- [ ] Refactor
- [ ] Feature
- [X] Bug Fix
- [ ] Optimization
- [ ] Documentation Update

## Description
When I try to install hunter_platform repo, the ros2_livox_simulation package dependency is required. I think it is better to add that package to the dependencies in package.xml.
